### PR TITLE
Allow tests to control how the faked-out Pollster library is mocked

### DIFF
--- a/screenpy/readthedocs/features/conftest.py
+++ b/screenpy/readthedocs/features/conftest.py
@@ -8,7 +8,6 @@ import pytest
 from screenpy import AnActor
 
 from ..abilities import ControlCameras, PollTheAudience
-from pollster import laughter_packet, tense_packet, connect_to_audience
 
 
 @pytest.fixture
@@ -25,19 +24,3 @@ def Polly() -> Generator:
     the_actor = AnActor.named("Polly").who_can(PollTheAudience())
     yield the_actor
     the_actor.exit()
-
-
-@pytest.hookimpl(hookwrapper=True, tryfirst=True)
-def pytest_runtest_setup(item: pytest.Item) -> Generator:
-    """This function makes the tests work in any order.
-
-    You probably won't have this function in your tests for real, but we
-    need to know which packet to load for our faked-out Pollster results.
-    """
-    side_effect = None
-    if "comedic" in item.name:
-        side_effect = laughter_packet
-    elif "dramatic" in item.name:
-        side_effect = tense_packet
-    connect_to_audience().poll_mood.side_effect = [side_effect]
-    yield

--- a/screenpy/readthedocs/features/test_mood.py
+++ b/screenpy/readthedocs/features/test_mood.py
@@ -3,6 +3,7 @@ Test our ability to influence the audience's mood with skillful camerawork.
 """
 
 from cam_py import Camera
+from pollster import laughter_packet, tense_packet, mock_mood
 from screenpy import AnActor, given, then, when
 from screenpy.actions import See
 from screenpy.resolutions import Equals
@@ -23,6 +24,7 @@ from ..resolutions import IsPalpable
 from ..scripts import GOOD_WILL_HUNTING, SHAUN_OF_THE_DEAD
 
 
+@mock_mood(tense_packet)
 def test_dramatic_moment(Cameron: AnActor, Polly: AnActor) -> None:
     """We can use the camera to create dramatic tension."""
     Cameron.has_cleanup_tasks(StopRecording())
@@ -41,6 +43,7 @@ def test_dramatic_moment(Cameron: AnActor, Polly: AnActor) -> None:
     then(Polly).should(See.the(AudienceTension(), IsPalpable()))
 
 
+@mock_mood(laughter_packet)
 def test_comedic_timing(Cameron: AnActor, Polly: AnActor) -> None:
     """We can use the camera to make funny moments."""
     Cameron.has_cleanup_tasks(StopRecording())

--- a/screenpy/readthedocs/pollster.py
+++ b/screenpy/readthedocs/pollster.py
@@ -4,6 +4,7 @@ Our audience-polling mock-library for the example!
 This library *purportedly* lets you to do polls on audiences. But it's a mock.
 """
 
+from functools import wraps
 from unittest import mock
 
 import constants
@@ -18,3 +19,17 @@ laughter_packet.top_mood = constants.LAUGHING
 laughter_packet.saturation = 50
 
 connect_to_audience = mock.Mock()
+
+
+def mock_mood(packet):
+    """This function allows tests to control how connect_to_audience is mocked."""
+
+    def decorator_mock_mood(func):
+        @wraps(func)
+        def wrapper_func(*args, **kwargs):
+            connect_to_audience().poll_mood.side_effect = [packet]
+            func(*args, **kwargs)
+
+        return wrapper_func
+
+    return decorator_mock_mood


### PR DESCRIPTION
Those who are new to mocking in python might find it challenging to setup mocked tests correctly.

By slightly modifying the example tests we can help them ease the learning curve.

See this [discussion](https://github.com/ScreenPyHQ/screenpy/issues/35) for more details.